### PR TITLE
Return component from service/start

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ and a [dependency injection mechanism](https://github.com/grzm/component.pedesta
 ## Installation
 
 ```clojure
-[com.nedap.staffing-solutions/components.pedestal "0.2.0"]
+[com.nedap.staffing-solutions/components.pedestal "0.2.1"]
 ```
 
 ## License

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject com.nedap.staffing-solutions/components.pedestal "0.2.0"
+(defproject com.nedap.staffing-solutions/components.pedestal "0.2.1"
   :description "Pedestal server as a Clojure Component"
 
   :url "https://github.com/nedap/components.pedestal"
@@ -22,8 +22,8 @@
 
   :dependencies [[ch.qos.logback/logback-classic "1.2.3" :exclusions [org.slf4j/slf4j-api]]
                  [com.grzm/component.pedestal "0.1.7"]
-                 [com.nedap.staffing-solutions/utils.modular "0.1.1"]
-                 [com.nedap.staffing-solutions/utils.spec "0.1.1"]
+                 [com.nedap.staffing-solutions/utils.modular "0.2.2"]
+                 [com.nedap.staffing-solutions/utils.spec "0.6.1"]
                  [com.stuartsierra/component "0.4.0"]
                  [io.pedestal/pedestal.jetty "0.5.5"]
                  [io.pedestal/pedestal.service "0.5.5"]


### PR DESCRIPTION
Running the specs on `service/component` failed because start returned a pedestal map.

as shown here: https://github.com/nedap/pep-forester/pull/75#issuecomment-478347111

This seemed to work on forester  :)