### PR TITLE
Fully restore old `nedap.components.pedestal.server.component` behavior

### DIFF
--- a/src/nedap/components/pedestal/server/component.clj
+++ b/src/nedap/components/pedestal/server/component.clj
@@ -22,7 +22,7 @@ Normally true, except on `:test` env."
 (defn should-start-or-stop? [service]
   (not (test? service)))
 
-(speced/defn start [{service                                      ::service/component
+(speced/defn start [{^::service/component  service                ::service/component
                      server                                       ::server
                      ^::start-stop-predicate start-stop-predicate ::start-stop-predicate
                      :as                                          this}]
@@ -35,7 +35,7 @@ Normally true, except on `:test` env."
                    will-start? pedestal.http/start)]
       (assoc this ::server server))))
 
-(speced/defn stop [{service                                      ::service/component
+(speced/defn stop [{^::service/component service                 ::service/component
                     server                                       ::server
                     ^::start-stop-predicate start-stop-predicate ::start-stop-predicate
                     :as                                          this}]
@@ -44,9 +44,13 @@ Normally true, except on `:test` env."
     (pedestal.http/stop server))
   (assoc this ::server nil))
 
-(defn new [& {::keys [start-stop-predicate]
-              :or    {start-stop-predicate should-start-or-stop?}
-              :as    this}]
-  (implement (or this {})
-    component/start start
-    component/stop  stop))
+(defn new
+  ([]
+   (nedap.components.pedestal.server.component/new {}))
+
+  ([{::keys [start-stop-predicate]
+     :or    {start-stop-predicate should-start-or-stop?}
+     :as    this}]
+   (implement (assoc this ::start-stop-predicate start-stop-predicate)
+     component/start start
+     component/stop  stop)))

--- a/test/functional/nedap/components/pedestal/server/component.clj
+++ b/test/functional/nedap/components/pedestal/server/component.clj
@@ -1,0 +1,42 @@
+(ns functional.nedap.components.pedestal.server.component
+  (:require
+   [clojure.test :refer :all]
+   [com.stuartsierra.component :as component]
+   [io.pedestal.http :as pedestal.http]
+   [nedap.components.pedestal.router.kws :as router]
+   [nedap.components.pedestal.server.component :as sut]
+   [nedap.components.pedestal.service.component :as service.component]
+   [nedap.components.pedestal.service.kws :as service]))
+
+(deftest lifecycle
+  (doseq [service-opts [{::service/defaults-kind :dev
+                         :env                    :test}
+                        {::service/defaults-kind :production
+                         :env                    :production}]]
+    (let [service (-> {::service/expand-routes?   false
+                       ::router/component         {::router/routes #{}}
+                       ::service/pedestal-options {::pedestal.http/port  8080
+                                                   ::pedestal.http/join? false}}
+                      (merge service-opts)
+                      service.component/new
+                      component/start)]
+      (testing "The component can be started and stopped without errors"
+        (are [input] (do
+                       (-> input
+                           (assoc ::service/component service)
+                           (component/start)
+                           (component/stop))
+                       true)
+          (sut/new)
+          (sut/new {::sut/start-stop-predicate (constantly false)})))
+
+      (testing "The `::sut/start-stop-predicate` option is honored"
+        (let [proof (atom false)
+              start-stop-predicate (fn [& _]
+                                     (reset! proof true)
+                                     false)]
+          (-> (sut/new {::sut/start-stop-predicate start-stop-predicate})
+              (assoc ::service/component service)
+              (component/start)
+              (component/stop))
+          (is @proof))))))


### PR DESCRIPTION
## Brief

Fixes nedap/components.pedestal#7

## QA plan

Review tests

## Author checklist

* [x] I have QAed the functionality
* [x] The PR has a reasonably reviewable size and a meaningful commit history
* [x] I have run the [branch formatter](https://github.com/nedap/formatting-stack/blob/332a419034ab46fad526a5592f4257353bd695b6/src/formatting_stack/branch_formatter.clj) and observed no new/significative warnings
* [ ] I have self-reviewed the PR prior to assignment, and its build passes
* Specifically, I have code-reviewed iteratively the PR considering the following aspects in isolation:
  * [x] Correctness
  * [x] Robustness (red paths, failure handling etc)
  * [x] Modular design
  * [x] Test coverage
  * [x] Spec coverage
  * [x] Documentation
  * [x] Security
  * [x] Performance
  * [ ] Cross-compatibility (Clojure/ClojureScript)

## Reviewer checklist

* [x] I have checked out this branch and reviewed it locally, running it
* [x] I have QAed the functionality
* I have code-reviewed iteratively the PR considering the following aspects in isolation:
  * [x] Business-facing correctness
  * [x] Robustness (red paths, failure handling etc)
  * [x] Modular design
  * [x] Test coverage
  * [x] Spec coverage
  * [x] Documentation
  * [x] Security
  * [x] Performance
  * [ ] Cross-compatibility (Clojure/ClojureScript)
