### PR TITLE
Make ::pedestal.http/join? option mandatory in production

### DIFF
--- a/nvd_suppressions.xml
+++ b/nvd_suppressions.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.1.xsd">
+<suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
   <suppress>
     <!-- Added on 2020-02-7 by vemv: only affects the .NET platform. See https://github.com/jeremylong/DependencyCheck/issues/2464 -->
     <notes><![CDATA[
@@ -7,5 +7,16 @@
     ]]></notes>
     <gav regex="true">^org\.msgpack:msgpack.0\.6\.12$</gav>
     <cve>CVE-2020-5234</cve>
+  </suppress>
+  <suppress>
+    <!-- Added on 2020-04-15 by jwkoelewijn: dependency-check fails on
+    fail on a jquery 3.4.1 This appears to be a bug in dependency-check, where jquery version 3.4.1 seems to be bundled
+    as a dependency to dependency-check itself:  https://github.com/jeremylong/DependencyCheck/issues/2593
+    This will be addressed in a new release of dependency-check, which has not been released yet -->
+    <notes><![CDATA[
+ file name: dependency-check-core-5.3.1.jar: jquery-3.4.1.min.js
+ ]]></notes>
+    <sha1>88523924351bac0b5d560fe0c5781e2556e7693d</sha1>
+    <vulnerabilityName>Regex in its jQuery.htmlPrefilter  sometimes may introduce XSS</vulnerabilityName>
   </suppress>
 </suppressions>

--- a/project.clj
+++ b/project.clj
@@ -86,7 +86,7 @@
 
              :provided {:dependencies [[com.google.guava/guava "25.1-jre" #_"not a real depenency - satisfies NVD"]]}
 
-             :nvd      {:plugins      [[lein-nvd "1.3.1"]]
+             :nvd      {:plugins      [[lein-nvd "1.4.0"]]
                         :nvd          {:suppression-file "nvd_suppressions.xml"}
                         ;; These are lein-nvd transitive dependencies, copied verbatim, which Lein could otherwise alter.
                         :dependencies [[com.esotericsoftware/minlog "1.3"]
@@ -97,7 +97,7 @@
                                        [joda-time "2.10" #_"For clj-time"]
                                        [org.apache.commons/commons-compress "1.19"]
                                        [org.json/json "20140107"]
-                                       [org.owasp/dependency-check-core "5.2.2"]]}
+                                       [org.owasp/dependency-check-core "5.3.2"]]}
 
              :ci       {:pedantic?    :abort
                         :jvm-opts     ["-Dclojure.main.report=stderr"]

--- a/src/nedap/components/pedestal/service/component.clj
+++ b/src/nedap/components/pedestal/service/component.clj
@@ -8,7 +8,8 @@
    [nedap.components.pedestal.router.kws :as router]
    [nedap.components.pedestal.service.kws :as service]
    [nedap.speced.def :as speced]
-   [nedap.utils.modular.api :refer [implement]]))
+   [nedap.utils.modular.api :refer [implement]]
+   [nedap.utils.spec.api :refer [check!]]))
 
 (def prod-map
   {::pedestal.http/resource-path     "/public"
@@ -26,11 +27,7 @@
                                           ::service/keys           [defaults-kind pedestal-options expand-routes?]
                                           :as                      ^::service/initialized-component this}]
   (let [dev? (= :dev defaults-kind)
-
-        _ (when (and (not dev?)
-                     (not (spec/valid? ::service/pedestal-production-options pedestal-options)))
-            (throw (ex-info "Invalid :pedestal-options for production"
-                            (spec/explain-data ::service/pedestal-production-options pedestal-options))))
+        _ (when-not dev? (check! ::service/pedestal-production-options pedestal-options))
 
         ;; routes may be passed directly (via `::router/component`) or indirectly (via `pedestal-options`). Handle that:
         routes (when routes

--- a/src/nedap/components/pedestal/service/component.clj
+++ b/src/nedap/components/pedestal/service/component.clj
@@ -9,6 +9,15 @@
    [nedap.speced.def :as speced]
    [nedap.utils.modular.api :refer [implement]]))
 
+(speced/def-with-doc ::pedestal.http/join?
+  "A true value blocks the thread until server ends.
+  
+  Warning: Bloking the server thread can interfere with shutdown hooks
+  that would need access to the started component system.
+  
+  Default to false (non-blocking)."
+  boolean?)
+
 (def prod-map
   {::pedestal.http/join?             false
    ::pedestal.http/resource-path     "/public"
@@ -19,8 +28,7 @@
                                       :ssl? false}})
 
 (def dev-map
-  {::pedestal.http/join?           false
-   ::pedestal.http/allowed-origins {:creds true :allowed-origins (constantly true)}
+  {::pedestal.http/allowed-origins {:creds true :allowed-origins (constantly true)}
    ::pedestal.http/secure-headers  {:content-security-policy-settings {:object-src "'none'"}}})
 
 (speced/defn ^::service/component start [{{::router/keys [routes]} ::router/component

--- a/src/nedap/components/pedestal/service/component.clj
+++ b/src/nedap/components/pedestal/service/component.clj
@@ -12,8 +12,8 @@
 (speced/def-with-doc ::pedestal.http/join?
   "A true value blocks the thread until server ends.
   
-  Warning: Bloking the server thread can interfere with shutdown hooks
-  that would need access to the started component system.
+  Warning: Blocking the server thread (true value)can interfere with shutdown
+  hooks that would need access to the started component/system.
   
   Default to false (non-blocking)."
   boolean?)

--- a/src/nedap/components/pedestal/service/component.clj
+++ b/src/nedap/components/pedestal/service/component.clj
@@ -10,7 +10,8 @@
    [nedap.utils.modular.api :refer [implement]]))
 
 (def prod-map
-  {::pedestal.http/resource-path     "/public"
+  {::pedestal.http/join?             false
+   ::pedestal.http/resource-path     "/public"
    ::pedestal.http/type              :jetty
    ::pedestal.http/port              8080
    ::pedestal.http/container-options {:h2c? true

--- a/src/nedap/components/pedestal/service/kws.cljc
+++ b/src/nedap/components/pedestal/service/kws.cljc
@@ -18,13 +18,15 @@ Warning: Blocking the server thread (`true` value) can interfere with shutdown
 hooks that would need access to the started Component System."
   boolean?)
 
-(speced/def-with-doc ::pedestal-production-options
-  "Somewhat more strict spec for pedestal-options when running in production."
-  (spec/keys :req [::pedestal.http/join?]))
-
 (speced/def-with-doc ::pedestal-options
   "To be deep-merged with the component's defaults."
-  map?)
+  (spec/keys :req []))
+
+(speced/def-with-doc ::pedestal-production-options
+  "Somewhat more strict spec for pedestal-options when running in production."
+  (spec/merge
+    ::pedestal-options
+    (spec/keys :req [::pedestal.http/join?])))
 
 (speced/def-with-doc ::expand-routes?
   "Should the routes be expanded with `io.pedestal.http.route/expand-routes`?

--- a/src/nedap/components/pedestal/service/kws.cljc
+++ b/src/nedap/components/pedestal/service/kws.cljc
@@ -1,6 +1,7 @@
 (ns nedap.components.pedestal.service.kws
   (:require
    [clojure.spec.alpha :as spec]
+   [io.pedestal.http :as pedestal.http]
    [nedap.components.pedestal.router.kws :as router]
    [nedap.speced.def :as speced]))
 
@@ -9,6 +10,17 @@
 (speced/def-with-doc ::defaults-kind
   "The kind of defaults to be used. Note that this a more constrained notion than 'environment' (which can include staging)."
   #{:dev :production})
+
+(speced/def-with-doc ::pedestal.http/join?
+  "A true value blocks the calling thread until server ends.
+
+Warning: Blocking the server thread (`true` value) can interfere with shutdown
+hooks that would need access to the started Component System."
+  boolean?)
+
+(speced/def-with-doc ::pedestal-production-options
+  "Somewhat more strict spec for pedestal-options when running in production."
+  (spec/keys :req [::pedestal.http/join?]))
 
 (speced/def-with-doc ::pedestal-options
   "To be deep-merged with the component's defaults."

--- a/test/unit/nedap/components/pedestal/service/component.clj
+++ b/test/unit/nedap/components/pedestal/service/component.clj
@@ -17,18 +17,31 @@
                                      (false? expected))))
 
       "Non filled"
-      {}                                                        false
+      {}                                                          false
 
       "No pedestal options"
       {::service/defaults-kind  :dev
        ::service/expand-routes? false
-       ::router/component       {::router/routes #{}}},         false
+       ::router/component       {::router/routes #{}}},           false
 
       "With pedestal options"
       {::service/defaults-kind    :dev
        ::service/expand-routes?   false
        ::router/component         {::router/routes #{}}
-       ::service/pedestal-options {::pedestal.http/port 8080}}, true))
+       ::service/pedestal-options {::pedestal.http/port 8080}},   true
+
+      "Without join? option in production"
+      {::service/defaults-kind    :production
+       ::service/expand-routes?   false
+       ::router/component         {::router/routes #{}}
+       ::service/pedestal-options {::pedestal.http/port 8080}},   false
+
+      "With join? option in production"
+      {::service/defaults-kind    :production
+       ::service/expand-routes?   false
+       ::router/component         {::router/routes #{}}
+       ::service/pedestal-options {::pedestal.http/port 8080
+                                   ::pedestal.http/join? false}}, true))
 
   (testing "pedestal options are observed"
     (testing "flat options are assoc'ed"


### PR DESCRIPTION
## Brief

Fixes #15

Makes the `::pedestal.http/join?` option mandatory when starting the service component. Will throw when it is not present when `default-kind` is anything different than `:dev`.

## QA plan

<!-- Please state a reproducible plan to prove this PR works. Attach screenshots, gifs, etc. if needed. Occasionally, sufficient test coverage removes the need for QAing. -->

## Author checklist

<!-- Please, before publicizing your PR, open it as a "WIP PR", and then review it using the following. -->

* [x] I have QAed the functionality
* [x] The PR has a reasonably reviewable size and a meaningful commit history
* [x] I have run the [branch formatter](https://github.com/nedap/formatting-stack/blob/332a419034ab46fad526a5592f4257353bd695b6/src/formatting_stack/branch_formatter.clj) and observed no new/significative warnings
* [x] The build passes
* [x] I have self-reviewed the PR prior to assignment
* Additionally, I have code-reviewed iteratively the PR considering the following aspects in isolation:
  * [x] Correctness
  * [x] Robustness (red paths, failure handling etc)
  * [x] Test coverage
  * [x] Spec coverage
  * [ ] Documentation
  * [ ] Security
  * [ ] Performance
  * [x] Breaking API changes

## Reviewer checklist

* [ ] I have checked out this branch and reviewed it locally, running it
* [ ] I have QAed the functionality
* [ ] I have reviewed the PR
* Additionally, I have code-reviewed iteratively the PR considering the following aspects in isolation:
  * [ ] Correctness
  * [ ] Robustness (red paths, failure handling etc)
  * [ ] Test coverage
  * [ ] Spec coverage
  * [ ] Documentation
  * [ ] Security
  * [ ] Performance
  * [ ] Breaking API changes
