### PR TITLE
Remove logging infra

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,6 @@ This library delivers:
 * A [Pedestal](https://github.com/pedestal/pedestal) server as a component
   * Featuring refined integration with the Reloaded workflow
     * Otherwise Pedestal<->Reloaded integration can be hacky or incomplete.
-  * Including logging dependencies, so that apps don't repeat the same dep declarations.
 * Pedestal service configuration
 * A [dependency injection mechanism](https://github.com/grzm/component.pedestal)
 * A spec-coercion interceptor

--- a/project.clj
+++ b/project.clj
@@ -1,9 +1,7 @@
 ;; Please don't bump the library version by hand - use ci.release-workflow instead.
 (defproject com.nedap.staffing-solutions/components.pedestal "2.0.0"
   ;; Please keep the dependencies sorted a-z.
-  :dependencies [[ch.qos.logback/logback-classic "1.2.3"
-                  :exclusions [org.slf4j/slf4j-api]]
-                 [com.grzm/component.pedestal "0.1.7"
+  :dependencies [[com.grzm/component.pedestal "0.1.7"
                   :exclusions [ring/ring-codec]]
                  [com.nedap.staffing-solutions/utils.modular "2.1.0"]
                  [com.nedap.staffing-solutions/speced.def "2.0.0"
@@ -13,10 +11,7 @@
                  [io.pedestal/pedestal.service "0.5.7"]
                  [medley "1.2.0"]
                  [org.clojure/clojure "1.10.1"]
-                 [org.clojure/tools.analyzer.jvm "0.7.3" #_"Transitive"]
-                 [org.slf4j/jcl-over-slf4j "1.7.26"]
-                 [org.slf4j/jul-to-slf4j "1.7.26"]
-                 [org.slf4j/log4j-over-slf4j "1.7.26"]]
+                 [org.clojure/tools.analyzer.jvm "0.7.3" #_"Transitive"]]
 
   :exclusions [org.clojure/clojurescript]
 


### PR DESCRIPTION
## Brief

`components.pedestal` pulls in slf4j bridges and a backend (logback), which can be unexpected for consumers.  This PR removes these dependencies, **requiring** the consumer to deal explicitly with logging. 

<!-- Which issue does this PR fix? Ideally, create an issue if there was none, so the problem in question is well stated. -->

## QA plan

<!-- Please state a reproducible plan to prove this PR works. Attach screenshots, gifs, etc. if needed. Occasionally, sufficient test coverage removes the need for QAing. -->

## Author checklist

<!-- Please, before publicizing your PR, open it as a "WIP PR", and then review it using the following. -->

* [x] I have QAed the functionality
* [x] The PR has a reasonably reviewable size and a meaningful commit history
* [ ] I have run the [branch formatter](https://github.com/nedap/formatting-stack/blob/332a419034ab46fad526a5592f4257353bd695b6/src/formatting_stack/branch_formatter.clj) and observed no new/significative warnings
* [x] The build passes
* [x] I have self-reviewed the PR prior to assignment
* Additionally, I have code-reviewed iteratively the PR considering the following aspects in isolation:
  * [x] Correctness
  * [ ] Robustness (red paths, failure handling etc)
  * [ ] Test coverage
  * [ ] Spec coverage
  * [ ] Documentation
  * [ ] Security
  * [ ] Performance
  * [ ] Breaking API changes

## Reviewer checklist

* [ ] I have checked out this branch and reviewed it locally, running it
* [ ] I have QAed the functionality
* [ ] I have reviewed the PR
* Additionally, I have code-reviewed iteratively the PR considering the following aspects in isolation:
  * [ ] Correctness
  * [ ] Robustness (red paths, failure handling etc)
  * [ ] Test coverage
  * [ ] Spec coverage
  * [ ] Documentation
  * [ ] Security
  * [ ] Performance
  * [ ] Breaking API changes
